### PR TITLE
feat: add data persistence

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   echoradio:
-    image: simonsecuritypedant/echoradio:latest
+    image: simonsecuritypedant/echoradio:1.1.0
     container_name: echoradio
     ports:
       - "8000:8000"   # Icecast
@@ -8,3 +8,11 @@ services:
     restart: unless-stopped
     environment:
       - FLASK_ENV=production
+    volumes:
+      - app-data:/app/data
+
+volumes:
+  app-data:
+
+# Inspect the contents of the volume with:
+# `docker run -it --rm -v echoradio_app-data:/vol busybox ls -l /vol/`


### PR DESCRIPTION
Adding a simple docker volume will allow the container's config to survive a restart without requiring a re-import. The existing "latest" tag is actually older than the 1.1.0 which has the import and export functionality.